### PR TITLE
add bank and cash account prefix in account_chart_template.xml

### DIFF
--- a/l10n_mk/data/account_chart_template.xml
+++ b/l10n_mk/data/account_chart_template.xml
@@ -13,6 +13,8 @@
         </record>
         <record id="l10n_mk_chart_template_kp" model="account.chart.template">
             <field name="name">Контен план</field>
+	    <field name="bank_account_code_prefix">100</field>
+   	    <field name="cash_account_code_prefix">102</field>
             <field name="currency_id" ref="base.MKD"/>
             <field name="code_digits">0</field>
             <field name="transfer_account_id" ref="transfer_account"/>


### PR DESCRIPTION
Dodaden e prefiks za avtomatsko generiranje na konta, koga se kreiraat novi dnevnici za banka i gotovina. Promenata e napravena na file-ot "l10n_mk/data/account_chart_template.xml".
Avtomatskoto kreiranje na ovie konta, na korisnikot kje mu zastedi vreme vo otvoranje na novi konta za novite dnevnici (banka i gotovina) i kje gi eliminira potencijalnite greski pri nivno kreiranje,